### PR TITLE
Fix Several Calculator Issues

### DIFF
--- a/examples/calculator/bin/Calculator.rb
+++ b/examples/calculator/bin/Calculator.rb
@@ -29,6 +29,7 @@ class Calculator
               [  4,  5,  6, "+" ] +
               [ 7,  8,  9, "-" ] +
               [ 0, ".","/","=" ]
+    @clear_display = false
   end  
 
 #  This method is called when any key is clicked.  It follows
@@ -46,18 +47,26 @@ class Calculator
   def button__clicked(button)
     case button.label
       when "C" then 
-        @builder["display"].text = ""
+        clear_display
       when "=" then
         begin # this doesn't catch all errors
            @builder["display"].text = eval(@builder["display"].text).to_s
         rescue
           @builder["display"].text = "error"
         end
+        @clear_display = true
+      when /[0-9]/ then
+        clear_display if @clear_display
+        @builder["display"].text = @builder["display"].text + button.label
       else 
         @builder["display"].text = @builder["display"].text + button.label
     end   
   end  
 
+  def clear_display
+    @builder["display"].text = ""
+    @clear_display = false
+  end
 
 
 end


### PR DESCRIPTION
(Your use of Ruby's "eval" method in this calculator is very clever and significantly simplifies the logic.  It should also make it simple to support features like parentheses in expressions in the future.)

In almost any physical, real-world calculator I'm familiar with, if I wanted to compute 2+2 and 3+3 I would click the following buttons:

2 + 2 = 3 + 3 =

But if I do that in this program,

2 + 2 =

shows "4", as expected, but then clicking 3 changes the display to "43".

Also, entering

1 / 0 =

displays "error", as expected.  If I then decide to compute 2 + 2, when I click "2" the display changes to "error2".

I appreciate that this sample is intended as an example of using VisualRuby, not an example of how to write calculator logic.  But these issues make the calculator less usable.

This patch fixes the above two issues.
